### PR TITLE
Feat/#1/diary page 일기 작성 페이지, 로딩 페이지 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
 import Write from './pages/Write';
+import Loading from './components/Loading';
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/write" element={<Write />} />
+      <Route path="/loading" element={<Loading />} />
     </Routes>
   );
 }

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -21,6 +21,7 @@ const LoadingContainer = styled.div`
   justify-content: center;
   align-items: center;
   gap: 45px;
+  user-select: none;
 `;
 
 const LoadingText = styled.span`
@@ -28,6 +29,7 @@ const LoadingText = styled.span`
   height: 22px;
   margin: 120px 0px 0px 0px;
   font-size: 20px;
+  user-select: none;
 `;
 
 const LoadingImage = styled.img`

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,5 +1,49 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+import LP from '../assets/images/LPilogue.svg';
+
+// 회전 애니메이션 정의
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const LoadingContainer = styled.div`
+  width: 390px;
+  margin: 0 auto;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 45px;
+`;
+
+const LoadingText = styled.span`
+  width: 78px;
+  height: 22px;
+  margin: 120px 0px 0px 0px;
+  font-size: 20px;
+`;
+
+const LoadingImage = styled.img`
+  width: 340px;
+  height: 312px;
+  margin: 0 25px;
+  animation: ${rotate} 10s linear infinite;
+`;
+
 const Loading = () => {
-  return <div>Loading</div>;
+  return (
+    <LoadingContainer>
+      <LoadingText>추천 중..</LoadingText>
+      <LoadingImage src={LP} />
+    </LoadingContainer>
+  );
 };
 
 export default Loading;

--- a/src/index.css
+++ b/src/index.css
@@ -37,3 +37,52 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* input, textarea 및 placeholder 태그 폰트 유지 */
+input,
+textarea {
+  font-family:
+    'Ownglyph',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    'Helvetica Neue',
+    sans-serif;
+  font-size: 16px; /* 필요에 따라 크기 조정 */
+  color: black; /* 텍스트 색상 */
+}
+
+/* placeholder 스타일 */
+input::placeholder,
+textarea::placeholder {
+  font-family:
+    'Ownglyph',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    'Helvetica Neue',
+    sans-serif;
+  font-size: 16px; /* 필요에 따라 크기 조정 */
+  color: #aaa; /* placeholder 색상 */
+}
+
+/* @keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+} */

--- a/src/pages/Write.jsx
+++ b/src/pages/Write.jsx
@@ -1,5 +1,101 @@
+import React, { useState } from 'react';
 const Write = () => {
-  return <div>일기 작성</div>;
+  const [text, setText] = useState('');
+  const [date, setDate] = useState('');
+
+  const handleTextChange = (event) => {
+    setText(event.target.value);
+  };
+
+  const handleDateChange = (event) => {
+    setDate(event.target.value);
+  };
+
+  // 오늘 날짜 및 3일 전 날짜 계산
+  const today = new Date();
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(today.getDate() - 3);
+  const todayString = today.toISOString().split('T')[0];
+  const threeDaysAgoString = threeDaysAgo.toISOString().split('T')[0];
+
+  return (
+    <div
+      style={{
+        padding: '20px',
+        maxWidth: '390px', // 컴포넌트 넓이 고정
+        width: '390px',
+        margin: '0 auto',
+        border: 'none',
+        backgroundColor: '#F9F2DF', // 전체 배경 색상 설정
+        userSelect: 'none',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column', // 세로로 정렬
+          gap: '15px', // 각 행 사이의 간격
+        }}
+      >
+        <button
+          onClick={() => alert('일기 저장 완료!')}
+          disabled={!date || text.length < 1} // 날짜 선택 및 최소 1글자 입력 시 활성화
+          style={{
+            backgroundColor: date && text.length > 0 ? '#56B7C4' : '#ccc',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '5px',
+            cursor: date && text.length > 0 ? 'pointer' : 'not-allowed',
+            width: '40px',
+            whiteSpace: 'nowrap',
+            alignSelf: 'flex-end',
+          }}
+        >
+          완료
+        </button>
+        <input
+          type="date"
+          value={date}
+          onChange={handleDateChange}
+          max={todayString} // 오늘 날짜까지 선택 가능
+          min={threeDaysAgoString} // 3일 전 날짜부터 선택 가능
+          onKeyDown={(e) => e.preventDefault()} // 키보드를 통한 입력 방지
+          style={{
+            width: '100%',
+            height: '30px',
+            backgroundColor: '#F9F2DF', // 입력 필드 배경 색상
+            border: 'none',
+            borderRadius: '4px',
+            outline: 'none', // 포커스 시 태두리 제거
+          }}
+        />
+      </div>
+
+      <hr style={{ border: '0.5px solid #ccc', margin: '15px 0' }} />
+
+      <textarea
+        placeholder="일기를 작성해보세요"
+        value={text}
+        onChange={handleTextChange}
+        spellCheck="false"
+        style={{
+          width: '100%',
+          height: '450px',
+          lineHeight: '1.25',
+          border: 'none', // 가장자리 제거
+          outline: 'none', // 포커스 시 외곽선 제거
+          backgroundColor: '#F9F2DF', // 텍스트 영역 배경 색상
+          resize: 'none', // 크기 조절 비활성화
+        }}
+        maxLength={500}
+      />
+      <div
+        style={{ textAlign: 'right', marginBottom: '10px', userSelect: 'none' }}
+      >
+        <span>{text.length}/500</span>
+      </div>
+    </div>
+  );
 };
 
 export default Write;

--- a/src/pages/Write.jsx
+++ b/src/pages/Write.jsx
@@ -1,7 +1,90 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+// Styled Components 정의
+// 가장 큰 Div
+const Container = styled.div`
+  max-width: 390px;
+  width: 390px;
+  margin: 0 auto;
+  border: none;
+  background-color: #f9f2df;
+  user-select: none;
+`;
+
+const Layout = styled.div`
+  display: flex;
+  margin-top: 12px;
+  flex-direction: column;
+  gap: 27px;
+`;
+
+const Button = styled.button`
+  background-color: ${(props) => (props.active ? '#56B7C4' : '#ccc')};
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: ${(props) => (props.active ? 'pointer' : 'not-allowed')};
+  width: 55px;
+  height: 35px;
+  margin-right: 27px;
+  white-space: nowrap;
+  align-self: flex-end;
+`;
+
+const InputDate = styled.input`
+  width: 100%;
+  height: 30px;
+  background-color: #f9f2df;
+  border: none;
+  border-radius: 4px;
+  outline: none;
+  padding: 0px 27px;
+  box-sizing: border-box;
+  pointer-events: ${(props) => (props.disabled ? 'none' : 'auto')};
+`;
+
+const TextareaContainer = styled.div`
+  position: relative;
+  margin: 24px 33px 0px 27px;
+`;
+
+const Textarea = styled.textarea`
+  width: 330px;
+  height: 450px;
+  line-height: 1.25;
+  border: none;
+  outline: none;
+  background-color: #f9f2df;
+  resize: none;
+`;
+
+const TextareaLabel = styled.span`
+  position: absolute;
+  width: 50px;
+  height: 20px;
+  bottom: 15px;
+  right: 8px;
+`;
+
+const Line = styled.hr`
+  width: 340px;
+  border: 0.5px solid #ccc;
+  margin-top: 17px;
+`;
+
 const Write = () => {
+  const today = new Date();
+  const threeDaysAgo = new Date();
+  threeDaysAgo.setDate(today.getDate() - 3);
+  const todayString = today.toISOString().split('T')[0];
+  const threeDaysAgoString = threeDaysAgo.toISOString().split('T')[0];
+
   const [text, setText] = useState('');
-  const [date, setDate] = useState('');
+  const [date, setDate] = useState(todayString);
+
+  const navigate = useNavigate();
 
   const handleTextChange = (event) => {
     setText(event.target.value);
@@ -11,90 +94,41 @@ const Write = () => {
     setDate(event.target.value);
   };
 
-  // 오늘 날짜 및 3일 전 날짜 계산
-  const today = new Date();
-  const threeDaysAgo = new Date();
-  threeDaysAgo.setDate(today.getDate() - 3);
-  const todayString = today.toISOString().split('T')[0];
-  const threeDaysAgoString = threeDaysAgo.toISOString().split('T')[0];
+  const handleButtonClick = () => {
+    if (date && text.length > 0) {
+      navigate('/loading'); // /loading 경로로 이동
+    }
+  };
 
   return (
-    <div
-      style={{
-        padding: '20px',
-        maxWidth: '390px', // 컴포넌트 넓이 고정
-        width: '390px',
-        margin: '0 auto',
-        border: 'none',
-        backgroundColor: '#F9F2DF', // 전체 배경 색상 설정
-        userSelect: 'none',
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column', // 세로로 정렬
-          gap: '15px', // 각 행 사이의 간격
-        }}
-      >
-        <button
-          onClick={() => alert('일기 저장 완료!')}
-          disabled={!date || text.length < 1} // 날짜 선택 및 최소 1글자 입력 시 활성화
-          style={{
-            backgroundColor: date && text.length > 0 ? '#56B7C4' : '#ccc',
-            color: '#fff',
-            border: 'none',
-            borderRadius: '5px',
-            cursor: date && text.length > 0 ? 'pointer' : 'not-allowed',
-            width: '40px',
-            whiteSpace: 'nowrap',
-            alignSelf: 'flex-end',
-          }}
-        >
+    <Container>
+      <Layout>
+        <Button onClick={handleButtonClick} active={text.length > 0}>
           완료
-        </button>
-        <input
+        </Button>
+        <InputDate
           type="date"
           value={date}
           onChange={handleDateChange}
-          max={todayString} // 오늘 날짜까지 선택 가능
-          min={threeDaysAgoString} // 3일 전 날짜부터 선택 가능
-          onKeyDown={(e) => e.preventDefault()} // 키보드를 통한 입력 방지
-          style={{
-            width: '100%',
-            height: '30px',
-            backgroundColor: '#F9F2DF', // 입력 필드 배경 색상
-            border: 'none',
-            borderRadius: '4px',
-            outline: 'none', // 포커스 시 태두리 제거
-          }}
+          max={todayString}
+          min={threeDaysAgoString}
+          onKeyDown={(e) => e.preventDefault()}
         />
-      </div>
+      </Layout>
 
-      <hr style={{ border: '0.5px solid #ccc', margin: '15px 0' }} />
+      <Line />
 
-      <textarea
-        placeholder="일기를 작성해보세요"
-        value={text}
-        onChange={handleTextChange}
-        spellCheck="false"
-        style={{
-          width: '100%',
-          height: '450px',
-          lineHeight: '1.25',
-          border: 'none', // 가장자리 제거
-          outline: 'none', // 포커스 시 외곽선 제거
-          backgroundColor: '#F9F2DF', // 텍스트 영역 배경 색상
-          resize: 'none', // 크기 조절 비활성화
-        }}
-        maxLength={500}
-      />
-      <div
-        style={{ textAlign: 'right', marginBottom: '10px', userSelect: 'none' }}
-      >
-        <span>{text.length}/500</span>
-      </div>
-    </div>
+      <TextareaContainer>
+        <Textarea
+          placeholder="일기를 작성해보세요"
+          value={text}
+          onChange={handleTextChange}
+          spellCheck="false"
+          maxLength={500}
+        />
+        <TextareaLabel>{text.length}/500</TextareaLabel>
+      </TextareaContainer>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

일기 작성 페이지 styled-component 형태로 코드 수정 및
로딩 페이지 작성 완료했습니다

## 2. 어떤 위험이나 장애를 발견했나요?

1. 일기 작성 페이지에 날짜를 고치는 input tag를 클릭했을 때 파란색 박스가 생기는 데 지우는 방법을 잘 모르겠어서 그냥 뒀습니다.
2. 로딩 페이지의 경우에 svg를 불러올 때 그대로 불러온 이후에 img 태그를 이용해서 가져왔습니다. ReactComponent를 이용하는
방법도 있다는데 그건 잘 모르겠어서 일단 img 태그를 이용해서 불러왔습니다.
3. 로딩 페이지의 경우에 분석 중 폰트의 크기를 임의로 20px로 상향 했습니다. (index css 기준 16px이 기본)
4. 일기 작성 페이지에서 폰트 크기를 20px로 할 경우 일기 작성 페이지가 500자가 넘어가면 현재 몇 자를 썼는지 나타내는 부분을 침범하는 경우가 발생할 수 있는 것을 확인 했습니다.

## 3. 관련 스크린샷을 첨부해주세요.
첫 일기 작성 화면
![image](https://github.com/user-attachments/assets/c1b1bde5-419f-4d46-b6b8-69c3849f34bb)

작성 후 완료 버튼 활성화 (기준: 글자 수 >0 이면 가능)
![image](https://github.com/user-attachments/assets/eb935552-1931-4e7b-92a3-2cf54ae9963d)

완료 버튼 누른 후 넘어간 모습
![image](https://github.com/user-attachments/assets/ddcbe3db-f397-4f75-9d3c-5358a52d64c7)



## 4. 완료 사항

1. 피그마에 따라 최대한 유사하게 margin 따라서 진행했습니다.(위에 알림 칸은 무시하고 계산했습니다)
2. 일기 작성 페이지 및 로딩 페이지 기초 구현을 완료했습니다

## 5. 추가 사항

리팩토링은 할 줄 몰라서 그냥 돌아가는 수준이어서 확인해주시면 감사하겠습니다!