### PR TITLE
feat: 마이페이지 및 일기 로딩 페이지 구현 완료

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,8 @@ import { Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
 import Write from './pages/Write';
 import Loading from './components/Loading';
+import Mypage from './pages/Mypage';
+import Details from './pages/Details';
 
 function App() {
   return (
@@ -9,6 +11,8 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/write" element={<Write />} />
       <Route path="/loading" element={<Loading />} />
+      <Route path="/mypage" element={<Mypage />} />
+      <Route path="/detail" element={<Details />} />
     </Routes>
   );
 }

--- a/src/pages/Details.jsx
+++ b/src/pages/Details.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const Container = styled.div`
+  max-width: 390px;
+  width: 390px;
+  margin: 0 auto;
+  min-height: 100vh;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  button {
+    border: none;
+    cursor: pointer;
+  }
+`;
+
+const Title = styled.h2`
+  text-align: left;
+`;
+
+const AlbumImage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 48px;
+
+  img {
+    width: 150px;
+    height: 150px;
+    border-radius: 10px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  }
+`;
+
+const AlbumText = styled.div`
+  font-weight: bold;
+  text-align: center;
+  margin-top: 28px;
+
+  span {
+    font-weight: normal;
+    font-size: 14px;
+    display: block;
+    margin-top: 5px;
+  }
+`;
+
+const Content = styled.div`
+  margin: 20px 29px;
+  line-height: 1.5;
+  white-space: pre-wrap; /* 줄바꿈 유지 */
+`;
+
+const DeleteButton = styled.button`
+  background-color: #c0392b;
+  color: white;
+  border: none;
+  padding: 8px 15px;
+  border-radius: 5px;
+  font-size: 14px;
+  cursor: pointer;
+  float: right;
+`;
+
+const DetailPage = () => {
+  const navigate = useNavigate('/mypage');
+
+  const handleBack = () => {
+    navigate(-1); // 뒤로 가기
+  };
+
+  const handleDelete = () => {
+    alert('일기가 삭제되었습니다.'); // 삭제 동작 (실제 삭제 로직 추가 필요)
+  };
+
+  return (
+    <Container>
+      {/* 헤더 */}
+      <Header>
+        {/* 타이틀 */}
+        <Title onClick={handleBack}>{`<`} 2024년 12월 1일</Title>
+        <DeleteButton onClick={handleDelete}>삭제</DeleteButton>
+      </Header>
+
+      {/* 앨범 이미지 */}
+      <AlbumImage>
+        <img src="https://via.placeholder.com/150" alt="앨범 이미지" />
+      </AlbumImage>
+
+      {/* 앨범 제목 */}
+      <AlbumText>
+        한 페이지가 될 수 있게
+        <span>데이식스 (DAY6)</span>
+      </AlbumText>
+
+      {/* 일기 내용 */}
+      <Content>
+        {`일기 내용을 볼 수 있어요
+일기니까 좀 손글씨 같은 폰트를 써볼까요?
+
+오늘은 날씨가 좋았다
+졸업작품을 만들어야 한다 너무 어렵다
+그냥 졸업시켜주세요`}
+      </Content>
+    </Container>
+  );
+};
+
+export default DetailPage;

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  max-width: 390px;
+  margin: 0 auto;
+  padding: 20px;
+  color: #333;
+  min-height: 100vh;
+`;
+
+const Title = styled.div`
+  font-size: 28px;
+  margin: 0;
+`;
+
+const Subtitle = styled.div`
+  margin-bottom: 15px;
+  color: #555;
+`;
+
+const Navigation = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+
+  button {
+    background: #56b7c4;
+    border: none;
+    border-radius: 5px;
+    padding: 5px 10px;
+    color: white;
+    cursor: pointer;
+
+    &:disabled {
+      background: #ccc;
+      cursor: not-allowed;
+    }
+  }
+`;
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+`;
+
+const Card = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  background: white;
+  border-radius: 10px;
+  padding: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    border-radius: 5px;
+  }
+
+  p {
+    margin: 10px;
+  }
+`;
+
+const Mypage = () => {
+  const today = new Date();
+  const [currentYear, setCurrentYear] = useState(today.getFullYear());
+  const [currentMonth, setCurrentMonth] = useState(today.getMonth() + 1);
+
+  const daysInMonth = new Date(currentYear, currentMonth, 0).getDate();
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate('/detail'); // 모든 카드 클릭 시 "/detail" 페이지로 이동
+  };
+
+  return (
+    <Container>
+      <Title>
+        {currentYear}년 {currentMonth}월
+      </Title>
+      <Subtitle>닉네임님이 기록한 노래들이에요.</Subtitle>
+
+      <Navigation>
+        <button
+          onClick={() => setCurrentMonth((prev) => (prev > 1 ? prev - 1 : 12))}
+        >
+          이전 달
+        </button>
+        <button
+          onClick={() => setCurrentMonth((prev) => (prev < 12 ? prev + 1 : 1))}
+          disabled={
+            currentYear === today.getFullYear() &&
+            currentMonth >= today.getMonth() + 1
+          }
+        >
+          다음 달
+        </button>
+      </Navigation>
+
+      <Grid>
+        {Array.from({ length: daysInMonth }, (_, index) => (
+          <Card key={index} onClick={handleCardClick}>
+            <img
+              src="https://via.placeholder.com/150"
+              alt={`앨범 이미지 ${index + 1}`}
+            />
+            <p>
+              {currentMonth}월 {index + 1}일
+            </p>
+          </Card>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+
+export default Mypage;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

마이페이지 및 일기 로딩 페이지 구현 완료 했습니다

## 2. 어떤 위험이나 장애를 발견했나요?

1. 마이페이지에서 달을 바꾸는 게 없어서 달을 바꾸는 로직을 추가 했습니다. 다만 미래로는 못가게 했는데 2024년 기준으로 2023년으로 이동하는 로직은 아직 작성하지 못했습니다.

## 3. 관련 스크린샷을 첨부해주세요.

마이페이지 화면
![image](https://github.com/user-attachments/assets/13867041-edd2-46ee-824c-3a415eaabf19)

일기 조회 화면
![image](https://github.com/user-attachments/assets/e074d7d4-dd57-4ebf-b57d-d9487ca95ff2)


## 4. 완료 사항

1. 마이페이지를 그리드를 이용해서 제작했습니다.
2. 그냥 앨범 아트만 있을 경우에 살짝 밋밋해서 뒤에 하얀 배경 추가했습니다.
3. 누르면 일단 /detail 하나의 단일 페이지로 이동합니다.

## 5. 추가 사항

그리드를 이용해서 30~31일 모든 내용을 확인할 수 있게 했습니다.
쓴 적 없는 경우 혹은 작성한 경우 등 다양한 경우에 대해서는 진행 못했고 UI 중심으로 개발 했습니다.

삭제 버튼의 경우 alert만 이용해서 구현되었고 실제로 삭제되지 않습니다.
2024년 12월 1일은 텍스트 데이터라서 어떤 앨범아트를 누르더라도 이 단일 페이지만 나타납니다.